### PR TITLE
Added possibility to specify unstructured remittance information

### DIFF
--- a/lib/sepa/direct_debit_order.rb
+++ b/lib/sepa/direct_debit_order.rb
@@ -244,10 +244,10 @@ class Sepa::DirectDebitOrder
   class MandateInformation < Struct.new(:identification, :signature_date, :sequence_type); end
 
   class DirectDebit
-    attr_accessor :debtor, :debtor_account, :end_to_end_id, :amount, :currency, :mandate_info
+    attr_accessor :debtor, :debtor_account, :end_to_end_id, :amount, :currency, :mandate_info, :remittance_information
 
-    def initialize debtor, debtor_account, end_to_end_id, amount, currency, mandate_info
-      @debtor, @debtor_account, @end_to_end_id, @amount, @currency, @mandate_info = debtor, debtor_account, end_to_end_id, amount, currency, mandate_info
+    def initialize debtor, debtor_account, end_to_end_id, amount, currency, mandate_info, remittance_information = nil
+      @debtor, @debtor_account, @end_to_end_id, @amount, @currency, @mandate_info, @remittance_information = debtor, debtor_account, end_to_end_id, amount, currency, mandate_info, remittance_information
     end
 
     def sequence_type
@@ -260,7 +260,8 @@ class Sepa::DirectDebitOrder
         "#{prefix}.instructed_amount"                                        => ("%.2f" % amount),
         "#{prefix}.instructed_amount_currency"                               => "EUR",
         "#{prefix}.direct_debit_transaction.mandate_related_information.mandate_identification" => mandate_info.identification,
-        "#{prefix}.direct_debit_transaction.mandate_related_information.date_of_signature"      => mandate_info.signature_date
+        "#{prefix}.direct_debit_transaction.mandate_related_information.date_of_signature"      => mandate_info.signature_date,
+        "#{prefix}.remittance_information.unstructured_remittance_information"                  => remittance_information
       }
       hsh = hsh.merge debtor.to_properties("#{prefix}.debtor", opts)
       hsh = hsh.merge debtor_account.to_properties("#{prefix}.debtor", opts)

--- a/lib/sepa/payments_initiation/pain00800104/direct_debit_transaction_information.rb
+++ b/lib/sepa/payments_initiation/pain00800104/direct_debit_transaction_information.rb
@@ -5,6 +5,7 @@ require "sepa/payments_initiation/pain00800104/payment_type_information"
 require "sepa/payments_initiation/pain00800104/direct_debit_transaction"
 require "sepa/payments_initiation/pain00800104/purpose_choice"
 require "sepa/payments_initiation/pain00800104/regulatory_reporting"
+require "sepa/payments_initiation/pain00800104/remittance_information_choice"
 
 class Sepa::PaymentsInitiation::Pain00800104::DirectDebitTransactionInformation < Sepa::Base
   definition "Provides information on the individual transaction(s) included in the message."
@@ -22,6 +23,7 @@ class Sepa::PaymentsInitiation::Pain00800104::DirectDebitTransactionInformation 
   attribute :instruction_for_creditor_agent, "InstrForCdtrAgt"
   attribute :purpose                       , "Purp"           , Sepa::PaymentsInitiation::Pain00800104::PurposeChoice
   attribute :regulatory_reporting          , "RgltryRptg"     , :[], Sepa::PaymentsInitiation::Pain00800104::RegulatoryReporting
+  attribute :remittance_information        , "RmtInf"         , Sepa::PaymentsInitiation::Pain00800104::RemittanceInformationChoice
 
   attr_accessor :instructed_amount_currency
 end

--- a/lib/sepa/payments_initiation/pain00800104/remittance_information_choice.rb
+++ b/lib/sepa/payments_initiation/pain00800104/remittance_information_choice.rb
@@ -1,0 +1,9 @@
+class Sepa::PaymentsInitiation::Pain00800104::RemittanceInformationChoice < Sepa::Base
+  attribute :unstructured_remittance_information , "Ustrd"
+  # don't think this is commonly used; would probably need a class
+  attribute :structured_remittance_information   , "Strd"
+
+  def empty?
+    [unstructured_remittance_information, structured_remittance_information].compact == []
+  end
+end

--- a/spec/sepa/direct_debit_order_spec.rb
+++ b/spec/sepa/direct_debit_order_spec.rb
@@ -5,24 +5,24 @@ require "time"
 
 describe Sepa::DirectDebitOrder do
 
-  def order sepa_identifier_class
+  def order sepa_identifier_class, remittance_information = false
     bank_account0 = Sepa::DirectDebitOrder::BankAccount.new "FRZIZIPAPARAZZI345789", "FRZZPPKOOKOO"
     debtor0 = Sepa::DirectDebitOrder::Party.new "DALTON/CONANMR", "64, Livva de Getamire", nil, "30005", "RENNES", "France", "Conan DALTON", "01234567890", "conan@dalton.sepa.i.hope.this.works"
     mandate0 = Sepa::DirectDebitOrder::MandateInformation.new("mandate-id-0", Date.parse("2010-11-18"), "RCUR")
-    dd00 = Sepa::DirectDebitOrder::DirectDebit.new debtor0, bank_account0, "MONECOLE REG F13789 PVT 3", 1231.31, "EUR", mandate0
-    dd01 = Sepa::DirectDebitOrder::DirectDebit.new debtor0, bank_account0, "MONECOLE REG F13791 PVT 3", 1133.33, "EUR", mandate0
+    dd00 = Sepa::DirectDebitOrder::DirectDebit.new debtor0, bank_account0, "MONECOLE REG F13789 PVT 3", 1231.31, "EUR", mandate0, remittance_information ? "Transaction 3" : nil
+    dd01 = Sepa::DirectDebitOrder::DirectDebit.new debtor0, bank_account0, "MONECOLE REG F13791 PVT 3", 1133.33, "EUR", mandate0, remittance_information ? "We take your money" : nil
 
     bank_account1 = Sepa::DirectDebitOrder::BankAccount.new "FRQUIQUIWIGWAM947551", "FRQQWIGGA"
     debtor1 = Sepa::DirectDebitOrder::Party.new "ADAMS/SAMUELMR", "256, Livva de Getamire", nil, "75048", "BERLIN", "Germany", "Samuel ADAMS", "09876543210", "samuel@adams.sepa.i.hope.this.works"
     mandate1 = Sepa::DirectDebitOrder::MandateInformation.new("mandate-id-1", Date.parse("2012-01-19"), "FRST")
-    dd10 = Sepa::DirectDebitOrder::DirectDebit.new debtor1, bank_account1, "MONECOLE REG F13790 PVT 3", 1732.32, "EUR", mandate1
-    dd11 = Sepa::DirectDebitOrder::DirectDebit.new debtor1, bank_account1, "MONECOLE REG F13792 PVT 3", 1034.34, "EUR", mandate1
+    dd10 = Sepa::DirectDebitOrder::DirectDebit.new debtor1, bank_account1, "MONECOLE REG F13790 PVT 3", 1732.32, "EUR", mandate1, remittance_information ? "An important transaction" : nil
+    dd11 = Sepa::DirectDebitOrder::DirectDebit.new debtor1, bank_account1, "MONECOLE REG F13792 PVT 3", 1034.34, "EUR", mandate1, remittance_information ? "Thank you, for the money" : nil
 
     bank_account2 = Sepa::DirectDebitOrder::BankAccount.new "  FR QU IQ UI WI GW\tAM   947 551  ", "FRQQWIGGA"
     debtor2 = Sepa::DirectDebitOrder::Party.new "Mr. James Joyce", "512, Livva de Meet Agir", nil, "75099", "LONDON", "Angleterre", "Johann S. BACH", "09876543210", "js@bach.sepa.i.hope.this.works"
     mandate2 = Sepa::DirectDebitOrder::MandateInformation.new("mandate-id-2", Date.parse("2013-06-08"), "RCUR")
-    dd20 = Sepa::DirectDebitOrder::DirectDebit.new debtor2, bank_account2, "MONECOLE REG F13793 PVT 3", 1935.35, "EUR", mandate2
-    dd21 = Sepa::DirectDebitOrder::DirectDebit.new debtor2, bank_account2, "MONECOLE REG F13794 PVT 3", 1236.36, "EUR", mandate2
+    dd20 = Sepa::DirectDebitOrder::DirectDebit.new debtor2, bank_account2, "MONECOLE REG F13793 PVT 3", 1935.35, "EUR", mandate2, remittance_information ? "Another one" : nil
+    dd21 = Sepa::DirectDebitOrder::DirectDebit.new debtor2, bank_account2, "MONECOLE REG F13794 PVT 3", 1236.36, "EUR", mandate2, remittance_information ? "Final transaction" : nil
 
     sepa_now = Time.local(1992, 2, 28, 18, 30, 0, 0, 0)
     Time.stub(:now).and_return sepa_now
@@ -42,6 +42,15 @@ describe Sepa::DirectDebitOrder do
     xml = o.to_xml :pain_008_001_version => "02"
     xml = check_doc_header_02 xml
     expected = File.read(File.expand_path("../expected_customer_direct_debit_initiation_v02.xml", __FILE__))
+    expected.force_encoding(Encoding::UTF_8) if expected.respond_to? :force_encoding
+    xml.should == expected
+  end
+
+  it "should produce v02 xml corresponding to the given inputs with unstructured remittance information" do
+    o = order Sepa::DirectDebitOrder::PrivateSepaIdentifier, true
+    xml = o.to_xml :pain_008_001_version => "02"
+    xml = check_doc_header_02 xml
+    expected = File.read(File.expand_path("../expected_customer_direct_debit_initiation_v02_with_remittance_information.xml", __FILE__))
     expected.force_encoding(Encoding::UTF_8) if expected.respond_to? :force_encoding
     xml.should == expected
   end

--- a/spec/sepa/expected_customer_direct_debit_initiation_v02_with_remittance_information.xml
+++ b/spec/sepa/expected_customer_direct_debit_initiation_v02_with_remittance_information.xml
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document>
+  <CstmrDrctDbtInitn>
+    <GrpHdr>
+      <MsgId>MSG0001</MsgId>
+      <CreDtTm>1992-02-28T18:30:00Z</CreDtTm>
+      <NbOfTxs>6</NbOfTxs>
+      <CtrlSum>8303.01</CtrlSum>
+      <InitgPty>
+        <Nm>SOFTIFY SARL</Nm>
+      </InitgPty>
+    </GrpHdr>
+    <PmtInf>
+      <PmtInfId>MONECOLE_PAYMENTS_20130703-FRST</PmtInfId>
+      <PmtMtd>DD</PmtMtd>
+      <NbOfTxs>2</NbOfTxs>
+      <CtrlSum>2766.66</CtrlSum>
+      <PmtTpInf>
+        <SvcLvl>
+          <Cd>SEPA</Cd>
+        </SvcLvl>
+        <LclInstrm>
+          <Cd>CORE</Cd>
+        </LclInstrm>
+        <SeqTp>FRST</SeqTp>
+      </PmtTpInf>
+      <ReqdColltnDt>2013-07-10</ReqdColltnDt>
+      <Cdtr>
+        <Nm>Mon Ecole</Nm>
+        <PstlAdr>
+          <Ctry>FR</Ctry>
+          <AdrLine>3, Livva de Getamire</AdrLine>
+          <AdrLine>75022 Paris</AdrLine>
+        </PstlAdr>
+      </Cdtr>
+      <CdtrAcct>
+        <Id>
+          <IBAN>FRGOOGOOYADDA9999999</IBAN>
+        </Id>
+      </CdtrAcct>
+      <CdtrAgt>
+        <FinInstnId>
+          <BIC>FRGGYELLOW99</BIC>
+        </FinInstnId>
+      </CdtrAgt>
+      <ChrgBr>SLEV</ChrgBr>
+      <CdtrSchmeId>
+        <Id>
+          <PrvtId>
+            <Othr>
+              <Id>FR123ZZZ010203</Id>
+              <SchmeNm>
+                <Prtry>SEPA</Prtry>
+              </SchmeNm>
+            </Othr>
+          </PrvtId>
+        </Id>
+      </CdtrSchmeId>
+      <DrctDbtTxInf>
+        <PmtId>
+          <EndToEndId>MONECOLE REG F13790 PVT 3</EndToEndId>
+        </PmtId>
+        <InstdAmt Ccy="EUR">1732.32</InstdAmt>
+        <DrctDbtTx>
+          <MndtRltdInf>
+            <MndtId>mandate-id-1</MndtId>
+            <DtOfSgntr>2012-01-19</DtOfSgntr>
+          </MndtRltdInf>
+        </DrctDbtTx>
+        <DbtrAgt>
+          <FinInstnId>
+            <BIC>FRQQWIGGA</BIC>
+          </FinInstnId>
+        </DbtrAgt>
+        <Dbtr>
+          <Nm>ADAMS/SAMUELMR</Nm>
+          <PstlAdr>
+            <Ctry>DE</Ctry>
+            <AdrLine>256, Livva de Getamire</AdrLine>
+            <AdrLine>75048 BERLIN</AdrLine>
+          </PstlAdr>
+        </Dbtr>
+        <DbtrAcct>
+          <Id>
+            <IBAN>FRQUIQUIWIGWAM947551</IBAN>
+          </Id>
+        </DbtrAcct>
+        <RmtInf>
+          <Ustrd>An important transaction</Ustrd>
+        </RmtInf>
+      </DrctDbtTxInf>
+      <DrctDbtTxInf>
+        <PmtId>
+          <EndToEndId>MONECOLE REG F13792 PVT 3</EndToEndId>
+        </PmtId>
+        <InstdAmt Ccy="EUR">1034.34</InstdAmt>
+        <DrctDbtTx>
+          <MndtRltdInf>
+            <MndtId>mandate-id-1</MndtId>
+            <DtOfSgntr>2012-01-19</DtOfSgntr>
+          </MndtRltdInf>
+        </DrctDbtTx>
+        <DbtrAgt>
+          <FinInstnId>
+            <BIC>FRQQWIGGA</BIC>
+          </FinInstnId>
+        </DbtrAgt>
+        <Dbtr>
+          <Nm>ADAMS/SAMUELMR</Nm>
+          <PstlAdr>
+            <Ctry>DE</Ctry>
+            <AdrLine>256, Livva de Getamire</AdrLine>
+            <AdrLine>75048 BERLIN</AdrLine>
+          </PstlAdr>
+        </Dbtr>
+        <DbtrAcct>
+          <Id>
+            <IBAN>FRQUIQUIWIGWAM947551</IBAN>
+          </Id>
+        </DbtrAcct>
+        <RmtInf>
+          <Ustrd>Thank you, for the money</Ustrd>
+        </RmtInf>
+      </DrctDbtTxInf>
+    </PmtInf>
+    <PmtInf>
+      <PmtInfId>MONECOLE_PAYMENTS_20130703-RCUR</PmtInfId>
+      <PmtMtd>DD</PmtMtd>
+      <NbOfTxs>4</NbOfTxs>
+      <CtrlSum>5536.35</CtrlSum>
+      <PmtTpInf>
+        <SvcLvl>
+          <Cd>SEPA</Cd>
+        </SvcLvl>
+        <LclInstrm>
+          <Cd>CORE</Cd>
+        </LclInstrm>
+        <SeqTp>RCUR</SeqTp>
+      </PmtTpInf>
+      <ReqdColltnDt>2013-07-10</ReqdColltnDt>
+      <Cdtr>
+        <Nm>Mon Ecole</Nm>
+        <PstlAdr>
+          <Ctry>FR</Ctry>
+          <AdrLine>3, Livva de Getamire</AdrLine>
+          <AdrLine>75022 Paris</AdrLine>
+        </PstlAdr>
+      </Cdtr>
+      <CdtrAcct>
+        <Id>
+          <IBAN>FRGOOGOOYADDA9999999</IBAN>
+        </Id>
+      </CdtrAcct>
+      <CdtrAgt>
+        <FinInstnId>
+          <BIC>FRGGYELLOW99</BIC>
+        </FinInstnId>
+      </CdtrAgt>
+      <ChrgBr>SLEV</ChrgBr>
+      <CdtrSchmeId>
+        <Id>
+          <PrvtId>
+            <Othr>
+              <Id>FR123ZZZ010203</Id>
+              <SchmeNm>
+                <Prtry>SEPA</Prtry>
+              </SchmeNm>
+            </Othr>
+          </PrvtId>
+        </Id>
+      </CdtrSchmeId>
+      <DrctDbtTxInf>
+        <PmtId>
+          <EndToEndId>MONECOLE REG F13789 PVT 3</EndToEndId>
+        </PmtId>
+        <InstdAmt Ccy="EUR">1231.31</InstdAmt>
+        <DrctDbtTx>
+          <MndtRltdInf>
+            <MndtId>mandate-id-0</MndtId>
+            <DtOfSgntr>2010-11-18</DtOfSgntr>
+          </MndtRltdInf>
+        </DrctDbtTx>
+        <DbtrAgt>
+          <FinInstnId>
+            <BIC>FRZZPPKOOKOO</BIC>
+          </FinInstnId>
+        </DbtrAgt>
+        <Dbtr>
+          <Nm>DALTON/CONANMR</Nm>
+          <PstlAdr>
+            <Ctry>FR</Ctry>
+            <AdrLine>64, Livva de Getamire</AdrLine>
+            <AdrLine>30005 RENNES</AdrLine>
+          </PstlAdr>
+        </Dbtr>
+        <DbtrAcct>
+          <Id>
+            <IBAN>FRZIZIPAPARAZZI345789</IBAN>
+          </Id>
+        </DbtrAcct>
+        <RmtInf>
+          <Ustrd>Transaction 3</Ustrd>
+        </RmtInf>
+      </DrctDbtTxInf>
+      <DrctDbtTxInf>
+        <PmtId>
+          <EndToEndId>MONECOLE REG F13791 PVT 3</EndToEndId>
+        </PmtId>
+        <InstdAmt Ccy="EUR">1133.33</InstdAmt>
+        <DrctDbtTx>
+          <MndtRltdInf>
+            <MndtId>mandate-id-0</MndtId>
+            <DtOfSgntr>2010-11-18</DtOfSgntr>
+          </MndtRltdInf>
+        </DrctDbtTx>
+        <DbtrAgt>
+          <FinInstnId>
+            <BIC>FRZZPPKOOKOO</BIC>
+          </FinInstnId>
+        </DbtrAgt>
+        <Dbtr>
+          <Nm>DALTON/CONANMR</Nm>
+          <PstlAdr>
+            <Ctry>FR</Ctry>
+            <AdrLine>64, Livva de Getamire</AdrLine>
+            <AdrLine>30005 RENNES</AdrLine>
+          </PstlAdr>
+        </Dbtr>
+        <DbtrAcct>
+          <Id>
+            <IBAN>FRZIZIPAPARAZZI345789</IBAN>
+          </Id>
+        </DbtrAcct>
+        <RmtInf>
+          <Ustrd>We take your money</Ustrd>
+        </RmtInf>
+      </DrctDbtTxInf>
+      <DrctDbtTxInf>
+        <PmtId>
+          <EndToEndId>MONECOLE REG F13793 PVT 3</EndToEndId>
+        </PmtId>
+        <InstdAmt Ccy="EUR">1935.35</InstdAmt>
+        <DrctDbtTx>
+          <MndtRltdInf>
+            <MndtId>mandate-id-2</MndtId>
+            <DtOfSgntr>2013-06-08</DtOfSgntr>
+          </MndtRltdInf>
+        </DrctDbtTx>
+        <DbtrAgt>
+          <FinInstnId>
+            <BIC>FRQQWIGGA</BIC>
+          </FinInstnId>
+        </DbtrAgt>
+        <Dbtr>
+          <Nm>Mr. James Joyce</Nm>
+          <PstlAdr>
+            <AdrLine>512, Livva de Meet Agir</AdrLine>
+            <AdrLine>75099 LONDON</AdrLine>
+          </PstlAdr>
+        </Dbtr>
+        <DbtrAcct>
+          <Id>
+            <IBAN>FRQUIQUIWIGWAM947551</IBAN>
+          </Id>
+        </DbtrAcct>
+        <RmtInf>
+          <Ustrd>Another one</Ustrd>
+        </RmtInf>
+      </DrctDbtTxInf>
+      <DrctDbtTxInf>
+        <PmtId>
+          <EndToEndId>MONECOLE REG F13794 PVT 3</EndToEndId>
+        </PmtId>
+        <InstdAmt Ccy="EUR">1236.36</InstdAmt>
+        <DrctDbtTx>
+          <MndtRltdInf>
+            <MndtId>mandate-id-2</MndtId>
+            <DtOfSgntr>2013-06-08</DtOfSgntr>
+          </MndtRltdInf>
+        </DrctDbtTx>
+        <DbtrAgt>
+          <FinInstnId>
+            <BIC>FRQQWIGGA</BIC>
+          </FinInstnId>
+        </DbtrAgt>
+        <Dbtr>
+          <Nm>Mr. James Joyce</Nm>
+          <PstlAdr>
+            <AdrLine>512, Livva de Meet Agir</AdrLine>
+            <AdrLine>75099 LONDON</AdrLine>
+          </PstlAdr>
+        </Dbtr>
+        <DbtrAcct>
+          <Id>
+            <IBAN>FRQUIQUIWIGWAM947551</IBAN>
+          </Id>
+        </DbtrAcct>
+        <RmtInf>
+          <Ustrd>Final transaction</Ustrd>
+        </RmtInf>
+      </DrctDbtTxInf>
+    </PmtInf>
+  </CstmrDrctDbtInitn>
+</Document>


### PR DESCRIPTION
While the End-To-End-Id technically is enough to identify a payment, customers love a bit more verbose information on the payment.

Implemented to be compatible with old way of calling things.
Spec might be improved but does the trick.
