### PR TITLE
Support for more "float-likes", Bignum, Non-String values.

### DIFF
--- a/spec/sepa/direct_debit_order_spec.rb
+++ b/spec/sepa/direct_debit_order_spec.rb
@@ -2,27 +2,37 @@
 
 require "spec_helper"
 require "time"
+require 'bigdecimal'
+require 'rational'
 
 describe Sepa::DirectDebitOrder do
 
-  def order sepa_identifier_class, remittance_information = false
+  AMOUNTS = {
+      :Float => [1231.31, 1133.33, 1732.32, 1034.34, 1935.35, 1236.36],
+      :BigDecimal => [BigDecimal.new('1231.31'), BigDecimal.new('1133.33'), BigDecimal.new('1732.32'), BigDecimal.new('1034.34'), BigDecimal.new('1935.35'), BigDecimal.new('1236.36')],
+      :Rational => [Rational.reduce(123131, 100), Rational.reduce(113333, 100), Rational.reduce(173232, 100), Rational.reduce(103434, 100), Rational.reduce(193535, 100), Rational.reduce(123636, 100)],
+  }
+
+  def order sepa_identifier_class, numeric_class = :Float, remittance_information = false
+    amounts = AMOUNTS[numeric_class]
+
     bank_account0 = Sepa::DirectDebitOrder::BankAccount.new "FRZIZIPAPARAZZI345789", "FRZZPPKOOKOO"
     debtor0 = Sepa::DirectDebitOrder::Party.new "DALTON/CONANMR", "64, Livva de Getamire", nil, "30005", "RENNES", "France", "Conan DALTON", "01234567890", "conan@dalton.sepa.i.hope.this.works"
     mandate0 = Sepa::DirectDebitOrder::MandateInformation.new("mandate-id-0", Date.parse("2010-11-18"), "RCUR")
-    dd00 = Sepa::DirectDebitOrder::DirectDebit.new debtor0, bank_account0, "MONECOLE REG F13789 PVT 3", 1231.31, "EUR", mandate0, remittance_information ? "Transaction 3" : nil
-    dd01 = Sepa::DirectDebitOrder::DirectDebit.new debtor0, bank_account0, "MONECOLE REG F13791 PVT 3", 1133.33, "EUR", mandate0, remittance_information ? "We take your money" : nil
+    dd00 = Sepa::DirectDebitOrder::DirectDebit.new debtor0, bank_account0, "MONECOLE REG F13789 PVT 3", amounts[0], "EUR", mandate0, remittance_information ? "Transaction 3" : nil
+    dd01 = Sepa::DirectDebitOrder::DirectDebit.new debtor0, bank_account0, "MONECOLE REG F13791 PVT 3", amounts[1], "EUR", mandate0, remittance_information ? "We take your money" : nil
 
     bank_account1 = Sepa::DirectDebitOrder::BankAccount.new "FRQUIQUIWIGWAM947551", "FRQQWIGGA"
     debtor1 = Sepa::DirectDebitOrder::Party.new "ADAMS/SAMUELMR", "256, Livva de Getamire", nil, "75048", "BERLIN", "Germany", "Samuel ADAMS", "09876543210", "samuel@adams.sepa.i.hope.this.works"
     mandate1 = Sepa::DirectDebitOrder::MandateInformation.new("mandate-id-1", Date.parse("2012-01-19"), "FRST")
-    dd10 = Sepa::DirectDebitOrder::DirectDebit.new debtor1, bank_account1, "MONECOLE REG F13790 PVT 3", 1732.32, "EUR", mandate1, remittance_information ? "An important transaction" : nil
-    dd11 = Sepa::DirectDebitOrder::DirectDebit.new debtor1, bank_account1, "MONECOLE REG F13792 PVT 3", 1034.34, "EUR", mandate1, remittance_information ? "Thank you, for the money" : nil
+    dd10 = Sepa::DirectDebitOrder::DirectDebit.new debtor1, bank_account1, "MONECOLE REG F13790 PVT 3", amounts[2], "EUR", mandate1, remittance_information ? "An important transaction" : nil
+    dd11 = Sepa::DirectDebitOrder::DirectDebit.new debtor1, bank_account1, "MONECOLE REG F13792 PVT 3", amounts[3], "EUR", mandate1, remittance_information ? "Thank you, for the money" : nil
 
     bank_account2 = Sepa::DirectDebitOrder::BankAccount.new "  FR QU IQ UI WI GW\tAM   947 551  ", "FRQQWIGGA"
     debtor2 = Sepa::DirectDebitOrder::Party.new "Mr. James Joyce", "512, Livva de Meet Agir", nil, "75099", "LONDON", "Angleterre", "Johann S. BACH", "09876543210", "js@bach.sepa.i.hope.this.works"
     mandate2 = Sepa::DirectDebitOrder::MandateInformation.new("mandate-id-2", Date.parse("2013-06-08"), "RCUR")
-    dd20 = Sepa::DirectDebitOrder::DirectDebit.new debtor2, bank_account2, "MONECOLE REG F13793 PVT 3", 1935.35, "EUR", mandate2, remittance_information ? "Another one" : nil
-    dd21 = Sepa::DirectDebitOrder::DirectDebit.new debtor2, bank_account2, "MONECOLE REG F13794 PVT 3", 1236.36, "EUR", mandate2, remittance_information ? "Final transaction" : nil
+    dd20 = Sepa::DirectDebitOrder::DirectDebit.new debtor2, bank_account2, "MONECOLE REG F13793 PVT 3", amounts[4], "EUR", mandate2, remittance_information ? "Another one" : nil
+    dd21 = Sepa::DirectDebitOrder::DirectDebit.new debtor2, bank_account2, "MONECOLE REG F13794 PVT 3", amounts[5], "EUR", mandate2, remittance_information ? "Final transaction" : nil
 
     sepa_now = Time.local(1992, 2, 28, 18, 30, 0, 0, 0)
     Time.stub(:now).and_return sepa_now
@@ -46,8 +56,26 @@ describe Sepa::DirectDebitOrder do
     xml.should == expected
   end
 
+  it "should produce v02 xml corresponding to the given inputs and BigDecimal amounts" do
+    o = order Sepa::DirectDebitOrder::PrivateSepaIdentifier, :BigDecimal
+    xml = o.to_xml :pain_008_001_version => "02"
+    xml = check_doc_header_02 xml
+    expected = File.read(File.expand_path("../expected_customer_direct_debit_initiation_v02.xml", __FILE__))
+    expected.force_encoding(Encoding::UTF_8) if expected.respond_to? :force_encoding
+    xml.should == expected
+  end
+
+  it "should produce v02 xml corresponding to the given inputs and Rational amounts" do
+    o = order Sepa::DirectDebitOrder::PrivateSepaIdentifier, :Rational
+    xml = o.to_xml :pain_008_001_version => "02"
+    xml = check_doc_header_02 xml
+    expected = File.read(File.expand_path("../expected_customer_direct_debit_initiation_v02.xml", __FILE__))
+    expected.force_encoding(Encoding::UTF_8) if expected.respond_to? :force_encoding
+    xml.should == expected
+  end
+
   it "should produce v02 xml corresponding to the given inputs with unstructured remittance information" do
-    o = order Sepa::DirectDebitOrder::PrivateSepaIdentifier, true
+    o = order Sepa::DirectDebitOrder::PrivateSepaIdentifier, :Float, true
     xml = o.to_xml :pain_008_001_version => "02"
     xml = check_doc_header_02 xml
     expected = File.read(File.expand_path("../expected_customer_direct_debit_initiation_v02_with_remittance_information.xml", __FILE__))
@@ -57,6 +85,24 @@ describe Sepa::DirectDebitOrder do
 
   it "should produce v04 xml corresponding to the given inputs" do
     o = order Sepa::DirectDebitOrder::PrivateSepaIdentifier
+    xml = o.to_xml :pain_008_001_version => "04"
+    xml = check_doc_header_04 xml
+    expected = File.read(File.expand_path("../expected_customer_direct_debit_initiation_v04.xml", __FILE__))
+    expected.force_encoding(Encoding::UTF_8) if expected.respond_to? :force_encoding
+    xml.should == expected
+  end
+
+  it "should produce v04 xml corresponding to the given inputs and BigDecimal amounts" do
+    o = order Sepa::DirectDebitOrder::PrivateSepaIdentifier, :BigDecimal
+    xml = o.to_xml :pain_008_001_version => "04"
+    xml = check_doc_header_04 xml
+    expected = File.read(File.expand_path("../expected_customer_direct_debit_initiation_v04.xml", __FILE__))
+    expected.force_encoding(Encoding::UTF_8) if expected.respond_to? :force_encoding
+    xml.should == expected
+  end
+
+  it "should produce v04 xml corresponding to the given inputs and Rational amounts" do
+    o = order Sepa::DirectDebitOrder::PrivateSepaIdentifier, :Rational
     xml = o.to_xml :pain_008_001_version => "04"
     xml = check_doc_header_04 xml
     expected = File.read(File.expand_path("../expected_customer_direct_debit_initiation_v04.xml", __FILE__))


### PR DESCRIPTION
- Replaced check for Fixnum by check for Integer to handle Bignum in the same way as Fixnum
- Replaced separate checks for Float and BigDecimal by a more generic check for Numeric and to_f
  to include support for Rational and maybe more exotic floating point numbers while not building
  any dependency on BigDecimal
- Added call to to_s for other values which is a no-op for String
- Added specs to check correct handling of Float, BigDecimal and Rational amounts

While strictly speaking most changes are of pure optional nature I like to emphasis that moving the "require bigdecimal" into the spec makes the lib less dependent on the presence of BigDecimal at runtime while maintaining support for handling BigDecimal. These changes emphasis on the inheritance of objects thus enabling a more objcet-oriented and problem aware usage by others.

The to_s-call may or may not help as this means that all values are accepted (previously only values implementing gsub) which can mean that you can reuse application-space objects as values (provided they implement to_s in a meaningful way) or mean that you don't get exceptions when you provide strange or nil values. For String-values this does not impose any change.
